### PR TITLE
postpone adds time to elapsed, not for each press

### DIFF
--- a/Libraries/Timer.h
+++ b/Libraries/Timer.h
@@ -36,7 +36,7 @@ public:
 
   void postpone(unsigned long postponeAmount) {
     postponed = true;
-    postponedDuration = postponedDuration + postponeAmount;
+    postponedDuration = timeElapsed + postponeAmount;
   }
 
   void start() {


### PR DESCRIPTION
postponeAmount now adds to timeElapsed rather than postponeDuration so that repetitive button presses don't result in very long duration 